### PR TITLE
update golangci-lint constant explicit type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bin/
 dist/
 
 .idea
+.vscode

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -2,14 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/runoncloud/kubectl-np-viewer/pkg/logger"
 	"github.com/runoncloud/kubectl-np-viewer/pkg/plugin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"os"
-	"strings"
 )
 
 var (

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,6 +3,10 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -13,9 +17,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"os"
-	"sort"
-	"strings"
 )
 
 const (
@@ -40,8 +41,8 @@ type TableLine struct {
 
 const (
 	PodSelector       SourceType = 1
-	NamespaceSelector            = 2
-	IpBlock                      = 3
+	NamespaceSelector SourceType = 2
+	IpBlock           SourceType = 3
 )
 
 // Runs the plugin


### PR DESCRIPTION
- Update golangci-lint constant explicit type

Before:
```golang
const (
	PodSelector       SourceType = 1
	NamespaceSelector            = 2
	IpBlock                      = 3
)
```

Fix:
```golang
const (
	PodSelector       SourceType = 1
	NamespaceSelector SourceType = 2
	IpBlock           SourceType = 3
)
```