### PR TITLE
Add ARM64 architecture support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     - darwin
     goarch:
     - amd64
+    - arm64
     - "386"
     env:
       - CGO_ENABLED=0

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -38,6 +38,39 @@ spec:
         - from: LICENSE
           to: "."
       bin: "np-viewer.exe"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/runoncloud/kubectl-np-viewer/releases/download/{{ .TagName }}/kubectl-np-viewer_linux_arm64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "./kubectl-np-viewer"
+          to: "np-viewer"
+        - from: LICENSE
+          to: "."
+      bin: "np-viewer"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/runoncloud/kubectl-np-viewer/releases/download/{{ .TagName }}/kubectl-np-viewer_darwin_arm64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "./kubectl-np-viewer"
+          to: "np-viewer"
+        - from: LICENSE
+          to: "."
+      bin: "np-viewer"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      {{addURIAndSha "https://github.com/runoncloud/kubectl-np-viewer/releases/download/{{ .TagName }}/kubectl-np-viewer_windows_arm64.zip" .TagName | indent 6 }}
+      files:
+        - from: "/kubectl-np-viewer.exe"
+          to: "np-viewer.exe"
+        - from: LICENSE
+          to: "."
+      bin: "np-viewer.exe"
   shortDescription: Network Policies rules viewer
   homepage: https://github.com/runoncloud/kubectl-np-viewer
   caveats: |


### PR DESCRIPTION
Right now, installing the plug-in on MacBooks M1 (using ARM64) raises an error:

```
failed to install some plugins: [np-viewer]: plugin "np-viewer" does not offer installation for this platform
```

This PR adds support for the ARM64 architecture.