### PR TITLE
Handle `matchExpressions` for podSelector

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -20,7 +20,6 @@ var (
 func RootCmd() *cobra.Command {
 	var ingress, egress, allNamespaces bool
 	var pod string
-	var addNp, delNp []string
 
 	cmd := &cobra.Command{
 		Use:           "kubectl-np-viewer",
@@ -71,11 +70,6 @@ func RootCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pod, "pod", "p", "",
 		"Only selects network policies rules applied to a specific pod")
 
-	cmd.Flags().StringSliceVarP(&addNp, "add-np", "a", []string{},
-		"Additional netpol to use without applying in the cluster.(must be relative path to netpol YAML file)")
-
-	cmd.Flags().StringSliceVarP(&delNp, "del-np", "d", []string{},
-		"Delete netpol from output. (must be netpol name))")
 	KubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
 	KubernetesConfigFlags.AddFlags(cmd.Flags())
 

--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -20,6 +20,7 @@ var (
 func RootCmd() *cobra.Command {
 	var ingress, egress, allNamespaces bool
 	var pod string
+	var addNp, delNp []string
 
 	cmd := &cobra.Command{
 		Use:           "kubectl-np-viewer",
@@ -70,6 +71,11 @@ func RootCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pod, "pod", "p", "",
 		"Only selects network policies rules applied to a specific pod")
 
+	cmd.Flags().StringSliceVarP(&addNp, "add-np", "a", []string{},
+		"Additional netpol to use without applying in the cluster.(must be relative path to netpol YAML file)")
+
+	cmd.Flags().StringSliceVarP(&delNp, "del-np", "d", []string{},
+		"Delete netpol from output. (must be netpol name))")
 	KubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
 	KubernetesConfigFlags.AddFlags(cmd.Flags())
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -293,6 +293,7 @@ func sortAndJoinLabelsForMatchLabels(labels map[string]string) string {
 }
 
 // Sorts and joins the labels with a new space delimiter by parsing MatchExpressions field
+// possible operators: Exists, DoesNotExist, In, NotIn
 func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelectorRequirement) string {
 	result := ""
 	for _, expression := range matchExpressions {
@@ -300,14 +301,14 @@ func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelecto
 		switch expression.Operator {
 		case metav1.LabelSelectorOpExists:
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "*")
-		case metav1.LabelSelectorOpNotIn:
-			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "^"+labelValues)
+		case metav1.LabelSelectorOpDoesNotExist:
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("!(%s)=%s", key, "*")
 		case metav1.LabelSelectorOpIn:
 			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, labelValues)
-		case metav1.LabelSelectorOpDoesNotExist:
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("!%s=%s", key, "*")
+		case metav1.LabelSelectorOpNotIn:
+			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "!"+labelValues)
 		}
 	}
 
@@ -392,17 +393,80 @@ func filterLinesBasedOnPodLabels(tableLines []TableLine, pod *corev1.Pod) []Tabl
 	for _, line := range tableLines {
 		if line.pods != Wildcard {
 			labels := strings.Split(line.pods, "\n")
-			for _, label := range labels {
-				keyValue := strings.Split(label, "=")
-				if pod.Labels[keyValue[0]] == keyValue[1] {
-					filteredTable = append(filteredTable, line)
+			appendLine := true
+			for _, labelCondition := range labels {
+				if !checkLabelCondition(labelCondition, pod) {
+					appendLine = false
+					break
 				}
+			}
+			if appendLine {
+				filteredTable = append(filteredTable, line)
 			}
 		} else {
 			filteredTable = append(filteredTable, line)
 		}
 	}
 	return filteredTable
+}
+
+// checkLabelCondition: check that a single label selector condition line is satisfied given a pod spec.
+// It support matchLabels and matchExpressions conditions type
+func checkLabelCondition(labelCondition string, pod *corev1.Pod) bool {
+	keyValue := strings.Split(labelCondition, "=")
+	key := keyValue[0]
+	value := keyValue[1]
+	if strings.HasPrefix(key, "!(") { // Label line: '!(label)=*'
+		return checkDoesNotExistCondition(key, pod)
+	} else if value == "*" { // prefix should be != '!(' also, Label line: 'label=*'
+		return checkExistCondition(key, pod)
+	} else if strings.HasPrefix(value, "!(") { // Label line: 'label=(value1|...|valueN)'
+		return checkNotInCondition(key, value, pod)
+	} else if strings.HasPrefix(value, "(") { // Label line: 'label=!(value1|...|valueN)'
+		return checkInCondition(key, value, pod)
+	} else if pod.Labels[keyValue[0]] != keyValue[1] { // simple label filter
+		return false
+	}
+
+	return true
+}
+
+// checkExistCondition: check an Exist filter against a pod spec. label line: 'label=*'.
+// Return true if the label key exist in pod spec
+func checkExistCondition(key string, pod *corev1.Pod) bool {
+	key = strings.TrimSuffix(strings.TrimPrefix(key, "("), ")")
+	_, exist := pod.Labels[key]
+	return exist
+}
+
+// checkDoesNotExistCondition: check a DoesNotExist filter against a pod spec. Label line: '!(label)=*'
+// // Return true if the label key does not exist in pod spec
+func checkDoesNotExistCondition(key string, pod *corev1.Pod) bool {
+	isolateKey := strings.TrimSuffix(strings.TrimPrefix(key, "!("), ")")
+	return !checkExistCondition(isolateKey, pod)
+}
+
+// checkInCondition: check an NotIn filter against a pod spec. label line: 'label=(value1|...|valueN)'
+// Return true if the label key if and only if the label exist and does not have specific values
+func checkInCondition(key, value string, pod *corev1.Pod) bool {
+	podLabelValue, exist := pod.Labels[key]
+	if !exist {
+		return false
+	}
+
+	values := strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "("), ")"), "|")
+	for _, value := range values {
+		if value == podLabelValue {
+			return true
+		}
+	}
+	return false
+}
+
+// checkNotInCondition: check an NotIn filter against a pod spec. label line: 'label=!(value1|...|valueN)'
+// Return true if the label key is not set in pod OR do not have specific values
+func checkNotInCondition(key, value string, pod *corev1.Pod) bool {
+	return !checkInCondition(key, strings.TrimPrefix(value, "!"), pod)
 }
 
 // Returns true if the slice contains the policy type

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -314,7 +314,6 @@ func sortAndJoinLabelsForMatchLabels(labels map[string]string) string {
 }
 
 // Sorts and joins the labels with a new space delimiter by parsing MatchExpressions field
-// possible operators: Exists, DoesNotExist, In, NotIn
 func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelectorRequirement) string {
 	result := ""
 	for _, expression := range matchExpressions {
@@ -322,14 +321,14 @@ func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelecto
 		switch expression.Operator {
 		case metav1.LabelSelectorOpExists:
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "*")
-		case metav1.LabelSelectorOpDoesNotExist:
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("^(%s)=%s", key, "*")
-		case metav1.LabelSelectorOpIn:
-			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, labelValues)
 		case metav1.LabelSelectorOpNotIn:
 			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "^"+labelValues)
+		case metav1.LabelSelectorOpIn:
+			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, labelValues)
+		case metav1.LabelSelectorOpDoesNotExist:
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("!%s=%s", key, "*")
 		}
 	}
 
@@ -414,80 +413,17 @@ func filterLinesBasedOnPodLabels(tableLines []TableLine, pod *corev1.Pod) []Tabl
 	for _, line := range tableLines {
 		if line.pods != Wildcard {
 			labels := strings.Split(line.pods, "\n")
-			appendLine := true
-			for _, labelCondition := range labels {
-				if !checkLabelCondition(labelCondition, pod) {
-					appendLine = false
-					break
+			for _, label := range labels {
+				keyValue := strings.Split(label, "=")
+				if pod.Labels[keyValue[0]] == keyValue[1] {
+					filteredTable = append(filteredTable, line)
 				}
-			}
-			if appendLine {
-				filteredTable = append(filteredTable, line)
 			}
 		} else {
 			filteredTable = append(filteredTable, line)
 		}
 	}
 	return filteredTable
-}
-
-// checkLabelCondition: check that a single label selector condition line is satisfied given a pod spec.
-// It support matchLabels and matchExpressions conditions type
-func checkLabelCondition(labelCondition string, pod *corev1.Pod) bool {
-	keyValue := strings.Split(labelCondition, "=")
-	key := keyValue[0]
-	value := keyValue[1]
-	if strings.HasPrefix(key, "^(") { // Label line: '^(label)=*'
-		return checkDoesNotExistCondition(key, pod)
-	} else if value == "*" { // prefix should be != '^(' also, Label line: 'label=*'
-		return checkExistCondition(key, pod)
-	} else if strings.HasPrefix(value, "^(") { // Label line: 'label=(value1|...|valueN)'
-		return checkNotInCondition(key, value, pod)
-	} else if strings.HasPrefix(value, "(") { // Label line: 'label=^(value1|...|valueN)'
-		return checkInCondition(key, value, pod)
-	} else if pod.Labels[keyValue[0]] != keyValue[1] { // simple label filter
-		return false
-	}
-
-	return true
-}
-
-// checkExistCondition: check an Exist filter against a pod spec. label line: 'label=*'.
-// Return true if the label key exist in pod spec
-func checkExistCondition(key string, pod *corev1.Pod) bool {
-	key = strings.TrimSuffix(strings.TrimPrefix(key, "("), ")")
-	_, exist := pod.Labels[key]
-	return exist
-}
-
-// checkDoesNotExistCondition: check a DoesNotExist filter against a pod spec. Label line: '^(label)=*'
-// // Return true if the label key does not exist in pod spec
-func checkDoesNotExistCondition(key string, pod *corev1.Pod) bool {
-	isolateKey := strings.TrimSuffix(strings.TrimPrefix(key, "^("), ")")
-	return !checkExistCondition(isolateKey, pod)
-}
-
-// checkInCondition: check an NotIn filter against a pod spec. label line: 'label=(value1|...|valueN)'
-// Return true if the label key if and only if the label exist and does not have specific values
-func checkInCondition(key, value string, pod *corev1.Pod) bool {
-	podLabelValue, exist := pod.Labels[key]
-	if !exist {
-		return false
-	}
-
-	values := strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "("), ")"), "|")
-	for _, value := range values {
-		if value == podLabelValue {
-			return true
-		}
-	}
-	return false
-}
-
-// checkNotInCondition: check an NotIn filter against a pod spec. label line: 'label=^(value1|...|valueN)'
-// Return true if the label key is not set in pod OR do not have specific values
-func checkNotInCondition(key, value string, pod *corev1.Pod) bool {
-	return !checkInCondition(key, strings.TrimPrefix(value, "^"), pod)
 }
 
 // Returns true if the slice contains the policy type

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubectl/pkg/cmd/util"
 )
 
@@ -77,6 +78,26 @@ func RunPlugin(configFlags *genericclioptions.ConfigFlags, cmd *cobra.Command) e
 	networkPolicies, err := getNetworkPolicies(clientset, namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to list network policies")
+	}
+	//add netpol
+	addNp, err := cmd.Flags().GetStringSlice("add-np")
+	if err != nil {
+		return errors.Wrap(err, "failed to get list from --add-np flag")
+	}
+	for _, yamlNp := range addNp {
+		netpol, err := decodeNetpolFromYaml(yamlNp)
+		if err != nil {
+			return errors.Wrap(err, "failed todecode yaml file")
+		}
+		networkPolicies.Items = append(networkPolicies.Items, *netpol)
+	}
+	// delete netpol
+	delNp, err := cmd.Flags().GetStringSlice("del-np")
+	if err != nil {
+		return errors.Wrap(err, "failed to get list from --del-np flag")
+	}
+	for _, netpol := range delNp {
+		networkPolicies.Items = deleteNetworkPolicy(networkPolicies.Items, netpol)
 	}
 
 	var tableLines []TableLine
@@ -477,4 +498,34 @@ func containsPolicyTypes(s []netv1.PolicyType, value netv1.PolicyType) bool {
 		}
 	}
 	return false
+}
+
+// decodeNetpolFromYaml: decode a NetworkPolicy YAML declaration within struct
+func decodeNetpolFromYaml(file string) (netpol *netv1.NetworkPolicy, err error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	stream, err := os.ReadFile(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read netpol YAML file")
+	}
+	obj, gKV, err := decode(stream, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode netpol YAML file")
+	}
+	if gKV.Kind == "NetworkPolicy" {
+		netpol = obj.(*netv1.NetworkPolicy)
+	}
+	return netpol, nil
+}
+
+// deleteNetworkPolicy: delete a network policy from a list
+func deleteNetworkPolicy(networkPolicies []netv1.NetworkPolicy, nameToDelete string) []netv1.NetworkPolicy {
+	var updatedList []netv1.NetworkPolicy
+
+	for _, policy := range networkPolicies {
+		if policy.Name != nameToDelete {
+			updatedList = append(updatedList, policy)
+		}
+	}
+
+	return updatedList
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -293,6 +293,7 @@ func sortAndJoinLabelsForMatchLabels(labels map[string]string) string {
 }
 
 // Sorts and joins the labels with a new space delimiter by parsing MatchExpressions field
+// possible operators: Exists, DoesNotExist, In, NotIn
 func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelectorRequirement) string {
 	result := ""
 	for _, expression := range matchExpressions {
@@ -300,14 +301,14 @@ func sortAndJoinLabelsForMatchExpressions(matchExpressions []metav1.LabelSelecto
 		switch expression.Operator {
 		case metav1.LabelSelectorOpExists:
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "*")
-		case metav1.LabelSelectorOpNotIn:
-			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "^"+labelValues)
+		case metav1.LabelSelectorOpDoesNotExist:
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("^(%s)=%s", key, "*")
 		case metav1.LabelSelectorOpIn:
 			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
 			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, labelValues)
-		case metav1.LabelSelectorOpDoesNotExist:
-			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("!%s=%s", key, "*")
+		case metav1.LabelSelectorOpNotIn:
+			labelValues := "(" + strings.Join(expression.Values, "|") + ")"
+			result = addCharIfNotEmpty(result, "\n") + fmt.Sprintf("%s=%s", key, "^"+labelValues)
 		}
 	}
 
@@ -392,17 +393,80 @@ func filterLinesBasedOnPodLabels(tableLines []TableLine, pod *corev1.Pod) []Tabl
 	for _, line := range tableLines {
 		if line.pods != Wildcard {
 			labels := strings.Split(line.pods, "\n")
-			for _, label := range labels {
-				keyValue := strings.Split(label, "=")
-				if pod.Labels[keyValue[0]] == keyValue[1] {
-					filteredTable = append(filteredTable, line)
+			appendLine := true
+			for _, labelCondition := range labels {
+				if !checkLabelCondition(labelCondition, pod) {
+					appendLine = false
+					break
 				}
+			}
+			if appendLine {
+				filteredTable = append(filteredTable, line)
 			}
 		} else {
 			filteredTable = append(filteredTable, line)
 		}
 	}
 	return filteredTable
+}
+
+// checkLabelCondition: check that a single label selector condition line is satisfied given a pod spec.
+// It support matchLabels and matchExpressions conditions type
+func checkLabelCondition(labelCondition string, pod *corev1.Pod) bool {
+	keyValue := strings.Split(labelCondition, "=")
+	key := keyValue[0]
+	value := keyValue[1]
+	if strings.HasPrefix(key, "^(") { // Label line: '^(label)=*'
+		return checkDoesNotExistCondition(key, pod)
+	} else if value == "*" { // prefix should be != '^(' also, Label line: 'label=*'
+		return checkExistCondition(key, pod)
+	} else if strings.HasPrefix(value, "^(") { // Label line: 'label=(value1|...|valueN)'
+		return checkNotInCondition(key, value, pod)
+	} else if strings.HasPrefix(value, "(") { // Label line: 'label=^(value1|...|valueN)'
+		return checkInCondition(key, value, pod)
+	} else if pod.Labels[keyValue[0]] != keyValue[1] { // simple label filter
+		return false
+	}
+
+	return true
+}
+
+// checkExistCondition: check an Exist filter against a pod spec. label line: 'label=*'.
+// Return true if the label key exist in pod spec
+func checkExistCondition(key string, pod *corev1.Pod) bool {
+	key = strings.TrimSuffix(strings.TrimPrefix(key, "("), ")")
+	_, exist := pod.Labels[key]
+	return exist
+}
+
+// checkDoesNotExistCondition: check a DoesNotExist filter against a pod spec. Label line: '^(label)=*'
+// // Return true if the label key does not exist in pod spec
+func checkDoesNotExistCondition(key string, pod *corev1.Pod) bool {
+	isolateKey := strings.TrimSuffix(strings.TrimPrefix(key, "^("), ")")
+	return !checkExistCondition(isolateKey, pod)
+}
+
+// checkInCondition: check an NotIn filter against a pod spec. label line: 'label=(value1|...|valueN)'
+// Return true if the label key if and only if the label exist and does not have specific values
+func checkInCondition(key, value string, pod *corev1.Pod) bool {
+	podLabelValue, exist := pod.Labels[key]
+	if !exist {
+		return false
+	}
+
+	values := strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "("), ")"), "|")
+	for _, value := range values {
+		if value == podLabelValue {
+			return true
+		}
+	}
+	return false
+}
+
+// checkNotInCondition: check an NotIn filter against a pod spec. label line: 'label=^(value1|...|valueN)'
+// Return true if the label key is not set in pod OR do not have specific values
+func checkNotInCondition(key, value string, pod *corev1.Pod) bool {
+	return !checkInCondition(key, strings.TrimPrefix(value, "^"), pod)
 }
 
 // Returns true if the slice contains the policy type


### PR DESCRIPTION
cf https://github.com/runoncloud/kubectl-np-viewer/issues/9

## Description

This MR aims to add `matchExpressions` treatment by `np-viewer`
It also change how  we select network policies rules applied to a specific pod

## Changes 

### Add `matchExpressions`
Change the way we deal with `sortAndJoinLabels` for pod and namespace selectors:
* 1 global function that take as args selectors
    * If there is `matchExpressions` it join labels using `sortAndJoinLabelsForMatchExpressions`
    * otherwise it joins labels like previously  (`sortAndJoinLabelsForMatchLabels`)

#### Rendered label lines

Depending on the operator:
* Exist: `label=*`
* DoesNotExist: `!(label)=*`
* NotIn: `label=!(value1|...|valueN)`
* In: `label=(value1|...|valueN)`

### Change line selection for a given pod
Theses changes entail that we also have to change the behaviour of the `filterLinesBasedOnPodLabels` function

It also fix the way it previously selected network policies rules applied to a specific pod:
* Indeed, previously it performed a loop on all labels use in selector. If one of them  statisfied the condition ⇒ add the line
* Nevertheless, label selection is AND'ed not OR'ed. Therefore, we have to ensure that all label selectors condition match with the pod given. 

_**Notes:**_ `matchExpressions` treatment is based on the spec ([details](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements))


